### PR TITLE
Fix to create all MongoDB indexes

### DIFF
--- a/pytpcc/drivers/mongodbdriver.py
+++ b/pytpcc/drivers/mongodbdriver.py
@@ -259,7 +259,8 @@ class MongodbDriver(AbstractDriver):
             if load_indexes and name in TABLE_INDEXES and \
             (self.denormalize or (self.denormalize == False and not name in MongodbDriver.DENORMALIZED_TABLES[1:])):
                 logging.debug("Creating index for %s" % name)
-                self.database[name].create_index(map(lambda x: (x, pymongo.ASCENDING), TABLE_INDEXES[name]))
+                for index in TABLE_INDEXES[name]:
+                	self.database[name].create_index(index)
         ## FOR
     
     ## ----------------------------------------------


### PR DESCRIPTION
The current version only created indexes for the first custom index on each table. 

> db.system.indexes.find()
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.ITEM", "name" : "_id_" }
> { "v" : 1, "key" : { "I_ID" : 1 }, "ns" : "tpcc.ITEM", "name" : "I_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.WAREHOUSE", "name" : "_id_" }
> { "v" : 1, "key" : { "W_ID" : 1 }, "ns" : "tpcc.WAREHOUSE", "name" : "W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.DISTRICT", "name" : "_id_" }
> { "v" : 1, "key" : { "D_ID" : 1, "D_W_ID" : 1 }, "ns" : "tpcc.DISTRICT", "name" : "D_ID_1_D_W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.CUSTOMER", "name" : "_id_" }
> { "v" : 1, "key" : { "C_ID" : 1, "C_D_ID" : 1, "C_W_ID" : 1 }, "ns" : "tpcc.CUSTOMER", "name" : "C_ID_1_C_D_ID_1_C_W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.STOCK", "name" : "_id_" }
> { "v" : 1, "key" : { "S_I_ID" : 1, "S_W_ID" : 1 }, "ns" : "tpcc.STOCK", "name" : "S_I_ID_1_S_W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.NEW_ORDER", "name" : "_id_" }
> { "v" : 1, "key" : { "NO_O_ID" : 1, "NO_D_ID" : 1, "NO_W_ID" : 1 }, "ns" : "tpcc.NEW_ORDER", "name" : "NO_O_ID_1_NO_D_ID_1_NO_W_ID_1" }

This fix creates indexes for all indexes defined in the TABLE_INDEXES:

> db.system.indexes.find()
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.ITEM", "name" : "_id_" }
> { "v" : 1, "key" : { "I_ID" : 1 }, "ns" : "tpcc.ITEM", "name" : "I_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.WAREHOUSE", "name" : "_id_" }
> { "v" : 1, "key" : { "W_ID" : 1 }, "ns" : "tpcc.WAREHOUSE", "name" : "W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.DISTRICT", "name" : "_id_" }
> { "v" : 1, "key" : { "D_ID" : 1 }, "ns" : "tpcc.DISTRICT", "name" : "D_ID_1" }
> { "v" : 1, "key" : { "D_W_ID" : 1 }, "ns" : "tpcc.DISTRICT", "name" : "D_W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.CUSTOMER", "name" : "_id_" }
> { "v" : 1, "key" : { "C_ID" : 1 }, "ns" : "tpcc.CUSTOMER", "name" : "C_ID_1" }
> { "v" : 1, "key" : { "C_D_ID" : 1 }, "ns" : "tpcc.CUSTOMER", "name" : "C_D_ID_1" }
> { "v" : 1, "key" : { "C_W_ID" : 1 }, "ns" : "tpcc.CUSTOMER", "name" : "C_W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.STOCK", "name" : "_id_" }
> { "v" : 1, "key" : { "S_I_ID" : 1 }, "ns" : "tpcc.STOCK", "name" : "S_I_ID_1" }
> { "v" : 1, "key" : { "S_W_ID" : 1 }, "ns" : "tpcc.STOCK", "name" : "S_W_ID_1" }
> { "v" : 1, "key" : { "_id" : 1 }, "ns" : "tpcc.NEW_ORDER", "name" : "_id_" }
> { "v" : 1, "key" : { "NO_O_ID" : 1 }, "ns" : "tpcc.NEW_ORDER", "name" : "NO_O_ID_1" }
> { "v" : 1, "key" : { "NO_D_ID" : 1 }, "ns" : "tpcc.NEW_ORDER", "name" : "NO_D_ID_1" }
> { "v" : 1, "key" : { "NO_W_ID" : 1 }, "ns" : "tpcc.NEW_ORDER", "name" : "NO_W_ID_1" }
