### PR TITLE
executor: ensure new-order items are unique

### DIFF
--- a/pytpcc/runtime/executor.py
+++ b/pytpcc/runtime/executor.py
@@ -138,7 +138,10 @@ class Executor:
             if rollback and i + 1 == ol_cnt:
                 i_ids.append(self.scaleParameters.items + 1)
             else:
-                i_ids.append(self.makeItemId())
+                i_id = self.makeItemId()
+                while i_id in i_ids:
+                    i_id = self.makeItemId()
+                i_ids.append(i_id)
 
             ## 1% of items are from a remote warehouse
             remote = (rand.number(1, 100) == 1)


### PR DESCRIPTION
After a quick lookup it appears that the TPC-C standard does not specify that the new-order items must be unique.
I think it makes more sense for them to be unique, don't you?