### PR TITLE
Load phase should honor remote warehouse req

### DIFF
--- a/pytpcc/runtime/loader.py
+++ b/pytpcc/runtime/loader.py
@@ -266,6 +266,13 @@ class Loader:
         ol_delivery_d = datetime.now()
         ol_quantity = constants.INITIAL_QUANTITY
 
+        ## 1% of items are from a remote warehouse
+        remote = (rand.number(1, 100) == 1)
+        if self.scaleParameters.warehouses > 1 and remote:
+            ol_supply_w_id = rand.numberExcluding(self.scaleParameters.starting_warehouse,
+                                                  self.scaleParameters.ending_warehouse,
+                                                  ol_w_id)
+
         if newOrder == False:
             ol_amount = 0.00
         else:


### PR DESCRIPTION
Currently execute phase honors TPCC 1% remote warehouse requirement but the loader phase does not.

This fixes the loader phase to honor the 1% remote warehouse requirement when generating line items.