### PR TITLE
Fix '--reset' and '--no-load' args combination

### DIFF
--- a/pytpcc/coordinator.py
+++ b/pytpcc/coordinator.py
@@ -145,7 +145,11 @@ if __name__ == '__main__':
     args = vars(aparser.parse_args())
 
     if args['debug']: logging.getLogger().setLevel(logging.DEBUG)
-        
+
+    ## Arguments validation
+    assert args['reset'] == False or args['no_load'] == False, \
+        "'--reset' and '--no-load' are incompatible with each other"
+
     ## Create a handle to the target client driver
     driverClass = createDriverClass(args['system'])
     assert driverClass != None, "Failed to find '%s' class" % args['system']

--- a/pytpcc/tpcc.py
+++ b/pytpcc/tpcc.py
@@ -204,7 +204,11 @@ if __name__ == '__main__':
     args = vars(aparser.parse_args())
 
     if args['debug']: logging.getLogger().setLevel(logging.DEBUG)
-        
+
+    ## Arguments validation
+    assert args['reset'] == False or args['no_load'] == False, \
+        "'--reset' and '--no-load' are incompatible with each other"
+
     ## Create a handle to the target client driver
     driverClass = createDriverClass(args['system'])
     assert driverClass != None, "Failed to find '%s' class" % args['system']


### PR DESCRIPTION
From a logical point of view, it is not possible to specify '--reset' and '--no-load' arguments at the same time. The current py-tpcc code state allows this, causing the database to be dropped, the new database not being created, and the run phase starting on an non-existent database. Based on this, it is proposed to introduce a check for the presence of a combination of these two arguments.